### PR TITLE
feat: Initial backend setup for self-hosted PostgreSQL

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,46 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import create_engine
+from app.core.config import settings
+from app.db.base import Base # Import Base and all models
+# Potentially, you might need to explicitly import all your models here
+# if app.db.base doesn't robustly import them due to load order,
+# though app.db.base is designed to handle this.
 
-app = FastAPI()
+# Create the database engine
+# The connect_args is often needed for SQLite, but usually not for PostgreSQL
+# For PostgreSQL, psycopg2 is the default driver if not specified in URI
+engine = create_engine(settings.SQLALCHEMY_DATABASE_URI, pool_pre_ping=True)
+
+def create_tables():
+    # This will create all tables defined in models that inherit from Base
+    # It's generally recommended to use Alembic for migrations in production
+    # But for development and initial setup, create_all is fine.
+    Base.metadata.create_all(bind=engine)
+
+app = FastAPI(
+    title=settings.PROJECT_NAME,
+    version=settings.PROJECT_VERSION,
+    openapi_url=f"{settings.API_V1_STR}/openapi.json" # Ensures OpenAPI spec is under API prefix
+)
+
+# Set all CORS enabled origins
+if settings.BACKEND_CORS_ORIGINS:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[str(origin) for origin in settings.BACKEND_CORS_ORIGINS],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+@app.on_event("startup")
+async def app_startup():
+    # This is one way to ensure tables are created when the app starts.
+    # Be cautious with this in production if using a more robust migration tool.
+    create_tables()
+    print("Database tables created (if they didn't exist).")
 
 @app.get("/")
 async def root():
-    return {"message": "Hello World"}
+    return {"message": f"Welcome to {settings.PROJECT_NAME}"}

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -5,9 +5,9 @@ from sqlalchemy.sql import func
 from app.db.base_class import Base
 
 class UserRole(enum.Enum):
-    REGULAR = "regular"
-    MEMBER = "member"
-    ADMIN = "admin"
+    STUDENT = "دانشجو"
+    ASSOCIATION_MEMBER = "عضو انجمن"
+    ASSOCIATION_ADMIN = "مدیر انجمن"
 
 class User(Base):
     __tablename__ = "users" # Explicitly defining, though Base would default to "users"
@@ -18,7 +18,7 @@ class User(Base):
     student_id = Column(String(50), unique=True, index=True, nullable=True) # Assuming student_id can be optional for some users initially
     phone_number = Column(String(20), unique=True, index=True, nullable=True) # Assuming phone_number can be optional
 
-    role = Column(DBEnum(UserRole), default=UserRole.REGULAR, nullable=False)
+    role = Column(DBEnum(UserRole), default=UserRole.STUDENT, nullable=False)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now(), nullable=False)

--- a/docs/sample_data.sql
+++ b/docs/sample_data.sql
@@ -7,10 +7,11 @@ BEGIN;
 -- For testing, if using raw SQL, you might insert known test hashes.
 -- Hashed password for 'password123' (example bcrypt hash, generate properly in app)
 -- UserRole enum values: 'regular', 'member', 'admin'
+-- UserRole enum values: 'دانشجو', 'عضو انجمن', 'مدیر انجمن'
 INSERT INTO users (id, full_name, email, password_hash, student_id, phone_number, role, created_at, updated_at) VALUES
-(1, 'Admin User', 'admin@example.com', '$2b$12$DUMMYHASHADMINLMNOPQRSTU.Vabcdefghijklmnopqrstuv.abcdefghijkl', 'admin001', '+989120000001', 'admin', NOW(), NOW()),
-(2, 'Member User', 'member@example.com', '$2b$12$DUMMYHASHMEMBERLMNOPQRS.Tabcdefghijklmnopqrstuv.abcdefghijkl', 'member001', '+989120000002', 'member', NOW(), NOW()),
-(3, 'Regular User', 'user@example.com', '$2b$12$DUMMYHASHREGULARLMNOPQR.Sabcdefghijklmnopqrstuv.abcdefghijkl', 'user001', '+989120000003', 'regular', NOW(), NOW());
+(1, 'مدیر سیستم', 'admin@example.com', '$2b$12$DUMMYHASHADMINLMNOPQRSTU.Vabcdefghijklmnopqrstuv.abcdefghijkl', 'admin001', '+989120000001', 'مدیر انجمن', NOW(), NOW()),
+(2, 'عضو نمونه', 'member@example.com', '$2b$12$DUMMYHASHMEMBERLMNOPQRS.Tabcdefghijklmnopqrstuv.abcdefghijkl', 'member001', '+989120000002', 'عضو انجمن', NOW(), NOW()),
+(3, 'دانشجوی نمونه', 'student@example.com', '$2b$12$DUMMYHASHREGULARLMNOPQR.Sabcdefghijklmnopqrstuv.abcdefghijkl', 'user001', '+989120000003', 'دانشجو', NOW(), NOW());
 
 -- News
 -- NewsStatus enum values: 'draft', 'published'


### PR DESCRIPTION
- Standardized user roles to 'دانشجو', 'عضو انجمن', 'مدیر انجمن' in Python models and sample data.
- Updated database configuration to support self-hosted PostgreSQL via .env file.
- Added mechanism in main.py to create database tables on startup.
- Configured basic JWT secret key handling (to be provided in .env).
- Enabled CORS middleware for frontend communication.