### PR TITLE
Fix frontend import error

### DIFF
--- a/src/components/admin/SubmissionTable.tsx
+++ b/src/components/admin/SubmissionTable.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/services/api";
+import api from "@/services/api";
 import {
   Table,
   TableBody,

--- a/src/components/admin/UserTable.tsx
+++ b/src/components/admin/UserTable.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/services/api";
+import api from "@/services/api";
 import {
   Table,
   TableBody,


### PR DESCRIPTION
The `SubmissionTable` and `UserTable` components were using a named import to import the `api` object from `src/services/api.ts`, but the `api` object was exported as a default export. This change updates the import statements to use a default import, which fixes the error.