### PR TITLE
feat: add run.py script to run the application

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,0 +1,4 @@
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
Adds a `run.py` script to the project root that runs the application using `uvicorn.run`. This ensures that the application is always run in the correct context and resolves the `ModuleNotFoundError`.

To run the application, use the following command from the project root:

`python run.py`