### PR TITLE
fix: Resolve CORS preflight error and empty favicon

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
         return self.DATABASE_URL
 
     # Backend CORS origins
-    BACKEND_CORS_ORIGINS: str = "http://localhost:5173,http://localhost:3000"
+    BACKEND_CORS_ORIGINS: str = "http://localhost:5173,http://127.0.0.1:5173,http://localhost:3000"
 
     @property
     def BACKEND_CORS_ORIGINS_LIST(self) -> list[str]:

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,5 +1,6 @@
 from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 from app import models, schemas
@@ -10,6 +11,10 @@ from app.services.user_service import user_service
 router = APIRouter()
 
 from sqlalchemy.exc import IntegrityError
+
+@router.options("/signup")
+async def signup_options():
+    return Response(status_code=200)
 
 @router.post("/signup", response_model=schemas.Token)
 def signup(

--- a/app/static/favicon.ico
+++ b/app/static/favicon.ico
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M8 0a8 8 0 100 16A8 8 0 008 0z"/></svg>


### PR DESCRIPTION
- Adds an explicit OPTIONS route for `/api/v1/auth/signup` to correctly handle CORS preflight requests and prevent 400 errors.
- Replaces the empty `favicon.ico` with a valid, non-empty SVG to ensure it has content and displays correctly.
- Adds `http://127.0.0.1:5173` to the list of allowed CORS origins to handle requests made via the IP address.