### PR TITLE
refactor: Remove all favicon handling logic

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,5 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 import logging
 
@@ -23,8 +21,6 @@ app = FastAPI(
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
     lifespan=lifespan
 )
-
-app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 if settings.BACKEND_CORS_ORIGINS_LIST:
     app.add_middleware(
@@ -63,10 +59,6 @@ app.include_router(membership_request_router.router, prefix=f"{settings.API_V1_S
 app.include_router(event_registration_router.router, prefix=f"{settings.API_V1_STR}", tags=["event-registrations"])
 app.include_router(user_router.router, prefix=f"{settings.API_V1_STR}/users", tags=["users"])
 app.include_router(notification_router.router, prefix=f"{settings.API_V1_STR}/notifications", tags=["notifications"])
-
-@app.get("/favicon.ico", include_in_schema=False)
-async def favicon():
-    return FileResponse("app/static/favicon.ico")
 
 @app.get("/")
 async def root():

--- a/app/static/favicon.ico
+++ b/app/static/favicon.ico
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M8 0a8 8 0 100 16A8 8 0 008 0z"/></svg>


### PR DESCRIPTION
- Deletes the `app/static/favicon.ico` file and the now-empty `app/static` directory.
- Removes the specific route for `/favicon.ico` from `app/main.py`.
- Removes the static file mounting logic and unused `StaticFiles` and `FileResponse` imports from `app/main.py`.

This reverts the application to its initial state where it does not handle favicon requests, which will result in a harmless 404 in server logs.